### PR TITLE
Implement real-time match log updates in Events

### DIFF
--- a/app/Events/GameLogAdded.php
+++ b/app/Events/GameLogAdded.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class GameLogAdded implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $type;
+    public $game_id;
+
+    protected $coachGroupId;
+
+    public function __construct(int $coachGroupId, int $gameId)
+    {
+        $this->coachGroupId = $coachGroupId;
+        $this->game_id = $gameId;
+        $this->type = 'log_added';
+    }
+
+    public function broadcastOn()
+    {
+        return new PrivateChannel("user.{$this->coachGroupId}.game.{$this->game_id}");
+    }
+
+    public function broadcastAs()
+    {
+        return 'log.added';
+    }
+}

--- a/app/Http/Controllers/Api/BroadCastScoreController.php
+++ b/app/Http/Controllers/Api/BroadCastScoreController.php
@@ -430,6 +430,10 @@ class BroadCastScoreController extends Controller
             return response()->noContent();
         }
 
+        if ($webSocketScorboard->action === 'EndMatch') {
+            return response()->noContent();
+        }
+
         return new BaseResponse(STATUS_CODE_OK, STATUS_CODE_OK, "scoreboardList", $webSocketScorboard);
     }
 
@@ -453,6 +457,10 @@ class BroadCastScoreController extends Controller
                 'user_id' => $coachGroupId,
                 'game_id' => $request->input('game_id'),
             ]);
+            return response()->noContent();
+        }
+
+        if ($webSocketScorboard->action === 'EndMatch') {
             return response()->noContent();
         }
 

--- a/app/Http/Controllers/Api/LogController.php
+++ b/app/Http/Controllers/Api/LogController.php
@@ -6,60 +6,73 @@ use App\Http\Controllers\Controller;
 use App\Http\Responses\BaseResponse;
 use App\Models\League;
 use App\Models\PlayGameLog;
-use App\Models\PlayGameMode;
 
 class LogController extends Controller
 {
- public function index(League $league, $match)
-{
+    private const TARGETDATA_FALLBACK_TYPES = [
+        'down',
+        'PositionNumber',
+        'short',
+        'medium',
+        'long',
+    ];
 
-    $isPractice = request()->boolean('is_practice', false); // safely cast to boole
+    public function index(League $league, $match)
+    {
+        $isPractice = request()->boolean('is_practice', false);
 
+        $logs = PlayGameLog::where('league_id', $league->id)
+            ->where('game_id', $match)
+            ->with(['myTeam', 'opponentTeam'])
+            ->get()
+            ->map(function ($log) use ($isPractice) {
+                $targetData = $this->resolveTargetData($log);
 
-    $logs = PlayGameLog::where('league_id', $league->id)
-        ->where('game_id', $match)
-        ->with(['myTeam', 'opponentTeam'])
-        ->get()
-        ->map(function ($log) use ($isPractice){
-            
-                if ($log->target == $log->my_team_id) {
-                    $targetData = $log->myTeam; // full myTeam object
-                } elseif ($log->target == $log->oponent_team_id) {
-                    $targetData = $log->opponentTeam; // full opponentTeam object
-                } else {
-                    $targetData = null; // fallback if target is not set
-                }
-            return [
+                return [
+                    'id' => $log->id,
+                    'players' => $isPractice
+                        ? $log->practice_players
+                        : $log->players,
+                    'weather_status' => $log->weather_status,
+                    'play_yardage_gain' => $log->play_yardage_gain,
+                    'quater' => $log->quater,
+                    'time' => $log->time,
+                    'current_position' => $log->current_position,
+                    'my_points' => $log->my_points,
+                    'target' => $log->target,
+                    'oponent_points' => $log->oponent_points,
+                    'downs' => $log->downs,
+                    'my_team' => $log->myTeam,
+                    'opponent_team' => $log->opponentTeam,
+                    'targetdata' => $targetData,
+                    'play' => $log->target_team,
+                    'type_of_log' => $log->type_of_log,
+                    'confirmed' => $log->confirmed,
+                ];
+            });
 
-                'id' => $log->id,
-                'players' => $isPractice
-                ? $log->practice_players
-                : $log->players,
-                'weather_status' => $log->weather_status,
-                'play_yardage_gain' => $log->play_yardage_gain,
-                'quater' => $log->quater,
-                'time' => $log->time,
-                'current_position' => $log->current_position,
-                'my_points' => $log->my_points,
-                'target' => $log->target, 
-                'oponent_points' => $log->oponent_points,
-                'downs' => $log->downs,
-                'my_team' => $log->myTeam,
-                'opponent_team' => $log->opponentTeam,
-                'targetdata' => $targetData,
-                'play' => $log->target_team,
-                'type_of_log' => $log->type_of_log,
-                'confirmed' => $log->confirmed,
-            ];
-        });
+        return new BaseResponse(
+            STATUS_CODE_OK,
+            STATUS_CODE_OK,
+            "Logs List",
+            $logs
+        );
+    }
 
-    return new BaseResponse(
-        STATUS_CODE_OK,
-        STATUS_CODE_OK,
-        "Logs List",
-        $logs
-    );
-}
+    private function resolveTargetData(PlayGameLog $log)
+    {
+        if ((string) $log->target === (string) $log->my_team_id) {
+            return $log->myTeam;
+        }
 
+        if ((string) $log->target === (string) $log->oponent_team_id) {
+            return $log->opponentTeam;
+        }
 
+        if (in_array($log->type_of_log, self::TARGETDATA_FALLBACK_TYPES, true)) {
+            return $log->myTeam ?? $log->opponentTeam;
+        }
+
+        return null;
+    }
 }

--- a/app/Http/Controllers/Api/PlayGameModeController.php
+++ b/app/Http/Controllers/Api/PlayGameModeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Events\GameLogAdded;
 use App\Http\Controllers\Controller;
 use App\Http\Responses\BaseResponse;
 use App\Models\PlayGameLog;
@@ -111,6 +112,16 @@ class PlayGameModeController extends Controller
 
         DB::commit();
 
+        try {
+            $user = auth()->user();
+            $coachGroupId = $user->role === 'head_coach'
+                ? $user->id
+                : $user->head_coach_id;
+            broadcast(new GameLogAdded($coachGroupId, (int) $value['game_id']));
+        } catch (\Exception $e) {
+            \Log::error('GameLogAdded broadcast failed: ' . $e->getMessage());
+        }
+
         return new BaseResponse(
             STATUS_CODE_OK,
             STATUS_CODE_OK,
@@ -182,6 +193,16 @@ class PlayGameModeController extends Controller
 
         // Commit the transaction
         DB::commit();
+
+        try {
+            $user = auth()->user();
+            $coachGroupId = $user->role === 'head_coach'
+                ? $user->id
+                : $user->head_coach_id;
+            broadcast(new GameLogAdded($coachGroupId, (int) $data[0]['game_id']));
+        } catch (\Exception $e) {
+            \Log::error('GameLogAdded broadcast failed: ' . $e->getMessage());
+        }
 
         return new BaseResponse(STATUS_CODE_OK, STATUS_CODE_OK, "Update Changes Added", $game);
     } catch (\Throwable $th) {

--- a/tests/Feature/GameModeTest.php
+++ b/tests/Feature/GameModeTest.php
@@ -274,4 +274,53 @@ class GameModeTest extends TestCase
 
         $response->dump()->assertStatus(200);
     }
+
+    public function test_scoreboard_get_returns_204_when_latest_action_is_end_match()
+    {
+        $user = $this->authAsCoach();
+        [$league, $team1, $team2] = $this->createLeagueWithTeams($user);
+
+        $mode = new PlayGameMode();
+        $mode->sport_id = $user->sport_id;
+        $mode->league_id = $league->id;
+        $mode->my_team_id = $team1->id;
+        $mode->oponent_team_id = $team2->id;
+        $mode->save();
+
+        \App\Models\WebsocketScoreboard::create([
+            'user_id' => $user->id,
+            'game_id' => $mode->id,
+            'left_score' => 7,
+            'right_score' => 3,
+            'action' => 'EndMatch',
+        ]);
+
+        $this->getJson('/api/scoreboard?game_id=' . $mode->id)
+            ->assertStatus(204);
+    }
+
+    public function test_scoreboard_get_returns_200_for_active_match()
+    {
+        $user = $this->authAsCoach();
+        [$league, $team1, $team2] = $this->createLeagueWithTeams($user);
+
+        $mode = new PlayGameMode();
+        $mode->sport_id = $user->sport_id;
+        $mode->league_id = $league->id;
+        $mode->my_team_id = $team1->id;
+        $mode->oponent_team_id = $team2->id;
+        $mode->save();
+
+        \App\Models\WebsocketScoreboard::create([
+            'user_id' => $user->id,
+            'game_id' => $mode->id,
+            'left_score' => 0,
+            'right_score' => 0,
+            'action' => 'INFO',
+        ]);
+
+        $this->getJson('/api/scoreboard?game_id=' . $mode->id)
+            ->assertStatus(200)
+            ->assertJsonPath('data.action', 'INFO');
+    }
 }

--- a/tests/Feature/LogControllerTest.php
+++ b/tests/Feature/LogControllerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 use App\Models\User;
 use App\Models\League;
+use App\Models\LeagueTeam;
 use App\Models\PlayGameLog;
 use Laravel\Sanctum\Sanctum;
 use Illuminate\Support\Facades\Schema;
@@ -17,11 +18,13 @@ class LogControllerTest extends TestCase
 
     protected User $user;
     protected League $league;
+    protected LeagueTeam $myTeam;
+    protected LeagueTeam $opponentTeam;
 
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         if (!Schema::hasTable('play_game_logs') || !Schema::hasTable('leagues')) {
             $this->markTestSkipped('Backend schema issue: required tables for log testing not found');
         }
@@ -32,7 +35,7 @@ class LogControllerTest extends TestCase
         ]);
 
         $sportId = DB::table('sports')->insertGetId(['title' => 'Test Sport']);
-        
+
         $this->league = new League();
         $this->league->user_id = $this->user->id;
         $this->league->sport_id = $sportId;
@@ -40,6 +43,16 @@ class LogControllerTest extends TestCase
         $this->league->title = 'Test League';
         $this->league->number_of_team = 2;
         $this->league->save();
+
+        $this->myTeam = new LeagueTeam();
+        $this->myTeam->league_id = $this->league->id;
+        $this->myTeam->team_name = 'Alpha';
+        $this->myTeam->save();
+
+        $this->opponentTeam = new LeagueTeam();
+        $this->opponentTeam->league_id = $this->league->id;
+        $this->opponentTeam->team_name = 'Beta';
+        $this->opponentTeam->save();
     }
 
     protected function auth()
@@ -55,13 +68,71 @@ class LogControllerTest extends TestCase
         $log = new PlayGameLog();
         $log->league_id = $this->league->id;
         $log->game_id = 1;
-        $log->my_team_id = 1;
-        $log->oponent_team_id = 2;
-        $log->target = 1;
+        $log->my_team_id = $this->myTeam->id;
+        $log->oponent_team_id = $this->opponentTeam->id;
+        $log->target = $this->myTeam->id;
         $log->save();
 
         $response = $this->getJson('/api/leagues/' . $this->league->id . '/matches/1/logs');
 
         $response->assertStatus(200);
+    }
+
+    public function test_targetdata_fallback_for_down_with_empty_target()
+    {
+        $this->auth();
+
+        $log = new PlayGameLog();
+        $log->league_id = $this->league->id;
+        $log->game_id = 1;
+        $log->my_team_id = $this->myTeam->id;
+        $log->oponent_team_id = $this->opponentTeam->id;
+        $log->target = '';
+        $log->type_of_log = 'down';
+        $log->downs = 2;
+        $log->save();
+
+        $response = $this->getJson('/api/leagues/' . $this->league->id . '/matches/1/logs');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.0.targetdata.team_name', 'Alpha');
+    }
+
+    public function test_targetdata_fallback_for_short_with_mismatched_target()
+    {
+        $this->auth();
+
+        $log = new PlayGameLog();
+        $log->league_id = $this->league->id;
+        $log->game_id = 1;
+        $log->my_team_id = $this->myTeam->id;
+        $log->oponent_team_id = $this->opponentTeam->id;
+        $log->target = 'invalid-target';
+        $log->type_of_log = 'short';
+        $log->save();
+
+        $response = $this->getJson('/api/leagues/' . $this->league->id . '/matches/1/logs');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.0.targetdata.team_name', 'Alpha');
+    }
+
+    public function test_targetdata_remains_null_for_unmatched_non_fallback_types()
+    {
+        $this->auth();
+
+        $log = new PlayGameLog();
+        $log->league_id = $this->league->id;
+        $log->game_id = 1;
+        $log->my_team_id = $this->myTeam->id;
+        $log->oponent_team_id = $this->opponentTeam->id;
+        $log->target = 'invalid-target';
+        $log->type_of_log = 'play';
+        $log->save();
+
+        $response = $this->getJson('/api/leagues/' . $this->league->id . '/matches/1/logs');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('data.0.targetdata', null);
     }
 }

--- a/tests/Feature/PracticeModeTest.php
+++ b/tests/Feature/PracticeModeTest.php
@@ -200,6 +200,55 @@ class PracticeModeTest extends TestCase
         $response->assertStatus(200);
     }
 
+    public function test_practice_scoreboard_get_returns_204_when_latest_action_is_end_match()
+    {
+        $user = $this->authAsCoach();
+        [$league, $team1, $team2] = $this->createLeagueWithTeams($user);
+
+        $mode = new PlayGameMode();
+        $mode->sport_id = $user->sport_id;
+        $mode->league_id = $league->id;
+        $mode->my_team_id = $team1->id;
+        $mode->oponent_team_id = $team2->id;
+        $mode->save();
+
+        \App\Models\WebsocketPracticeScoreboard::create([
+            'user_id' => $user->id,
+            'game_id' => $mode->id,
+            'left_score' => 7,
+            'right_score' => 3,
+            'action' => 'EndMatch',
+        ]);
+
+        $this->getJson('/api/practice-scoreboard?game_id=' . $mode->id)
+            ->assertStatus(204);
+    }
+
+    public function test_practice_scoreboard_get_returns_200_for_active_match()
+    {
+        $user = $this->authAsCoach();
+        [$league, $team1, $team2] = $this->createLeagueWithTeams($user);
+
+        $mode = new PlayGameMode();
+        $mode->sport_id = $user->sport_id;
+        $mode->league_id = $league->id;
+        $mode->my_team_id = $team1->id;
+        $mode->oponent_team_id = $team2->id;
+        $mode->save();
+
+        \App\Models\WebsocketPracticeScoreboard::create([
+            'user_id' => $user->id,
+            'game_id' => $mode->id,
+            'left_score' => 0,
+            'right_score' => 0,
+            'action' => 'INFO',
+        ]);
+
+        $this->getJson('/api/practice-scoreboard?game_id=' . $mode->id)
+            ->assertStatus(200)
+            ->assertJsonPath('data.action', 'INFO');
+    }
+
     public function test_can_delete_practice_scoreboard()
     {
         $user = $this->authAsCoach();


### PR DESCRIPTION
Implement logic to return 204 No Content for scoreboard requests when the latest action is 'EndMatch' in BroadCastScoreController and PracticeModeTest. Refactor LogController to enhance target data resolution with fallback handling for specific log types. Add tests to verify scoreboard behavior for both active and ended matches.