### PR TITLE
refactor: update devices table schema and foreign key handling

### DIFF
--- a/database/migrations/2026_06_16_000001_create_devices_table.php
+++ b/database/migrations/2026_06_16_000001_create_devices_table.php
@@ -18,9 +18,8 @@ return new class extends Migration
             $table->string('pairing_code', 4)->unique();
             $table->string('qr_token')->nullable()->unique();
             $table->string('status')->default('pending');
-            $table->integer('team_id')->nullable();
-            $table->foreign('team_id')->references('id')->on('league_teams')->nullOnDelete();
-            $table->foreignId('user_id')->nullable()->constrained('users')->onDelete('cascade');
+            $table->unsignedBigInteger('team_id')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
             $table->timestamp('paired_at')->nullable();
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2026_06_18_000001_fix_devices_team_id_foreign_key.php
+++ b/database/migrations/2026_06_18_000001_fix_devices_team_id_foreign_key.php
@@ -1,78 +1,16 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
     public function up(): void
     {
-        if (! Schema::hasTable('devices') || ! Schema::hasTable('league_teams')) {
-            return;
-        }
-
-        Schema::table('devices', function (Blueprint $table) {
-            $table->integer('team_id')->nullable()->change();
-        });
-
-        $existingFk = DB::selectOne(
-            "SELECT CONSTRAINT_NAME
-             FROM information_schema.KEY_COLUMN_USAGE
-             WHERE TABLE_SCHEMA = DATABASE()
-               AND TABLE_NAME = 'devices'
-               AND COLUMN_NAME = 'team_id'
-               AND REFERENCED_TABLE_NAME IS NOT NULL
-             LIMIT 1"
-        );
-
-        if ($existingFk?->CONSTRAINT_NAME) {
-            Schema::table('devices', function (Blueprint $table) use ($existingFk) {
-                $table->dropForeign($existingFk->CONSTRAINT_NAME);
-            });
-        }
-
-        $leagueTeamsFk = DB::selectOne(
-            "SELECT CONSTRAINT_NAME
-             FROM information_schema.KEY_COLUMN_USAGE
-             WHERE TABLE_SCHEMA = DATABASE()
-               AND TABLE_NAME = 'devices'
-               AND COLUMN_NAME = 'team_id'
-               AND REFERENCED_TABLE_NAME = 'league_teams'
-             LIMIT 1"
-        );
-
-        if (! $leagueTeamsFk) {
-            Schema::table('devices', function (Blueprint $table) {
-                $table->foreign('team_id')
-                    ->references('id')
-                    ->on('league_teams')
-                    ->nullOnDelete();
-            });
-        }
+        // No-op: devices.team_id is unsignedBigInteger without FK (see create_devices_table).
     }
 
     public function down(): void
     {
-        if (! Schema::hasTable('devices')) {
-            return;
-        }
-
-        $existingFk = DB::selectOne(
-            "SELECT CONSTRAINT_NAME
-             FROM information_schema.KEY_COLUMN_USAGE
-             WHERE TABLE_SCHEMA = DATABASE()
-               AND TABLE_NAME = 'devices'
-               AND COLUMN_NAME = 'team_id'
-               AND REFERENCED_TABLE_NAME IS NOT NULL
-             LIMIT 1"
-        );
-
-        if ($existingFk?->CONSTRAINT_NAME) {
-            Schema::table('devices', function (Blueprint $table) use ($existingFk) {
-                $table->dropForeign($existingFk->CONSTRAINT_NAME);
-            });
-        }
+        //
     }
 };


### PR DESCRIPTION
- Changed `team_id` and `user_id` columns to use `unsignedBigInteger` type for better compatibility.
- Removed foreign key constraints and related checks in the migration for `team_id`, simplifying the migration process.
- Updated comments to clarify the current state of the `devices` table structure.