### PR TITLE
refactor: update league_device table schema to remove foreign key constraints

### DIFF
--- a/database/migrations/2026_06_16_000002_create_league_device_table.php
+++ b/database/migrations/2026_06_16_000002_create_league_device_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('league_device', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('league_id')->constrained('leagues')->onDelete('cascade');
-            $table->foreignId('device_id')->constrained('devices')->onDelete('cascade');
+            $table->unsignedBigInteger('league_id');
+            $table->unsignedBigInteger('device_id');
             $table->timestamps();
 
             $table->unique(['league_id', 'device_id']);

--- a/database/migrations/2026_06_16_000003_add_device_id_to_play_game_modes_table.php
+++ b/database/migrations/2026_06_16_000003_add_device_id_to_play_game_modes_table.php
@@ -12,7 +12,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('play_game_modes', function (Blueprint $table) {
-            $table->foreignId('device_id')->nullable()->after('user_id')->constrained('devices')->onDelete('set null');
+            if (! Schema::hasColumn('play_game_modes', 'device_id')) {
+                $table->unsignedBigInteger('device_id')->nullable()->after('user_id');
+            }
         });
     }
 
@@ -22,8 +24,9 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('play_game_modes', function (Blueprint $table) {
-            $table->dropForeign(['device_id']);
-            $table->dropColumn('device_id');
+            if (Schema::hasColumn('play_game_modes', 'device_id')) {
+                $table->dropColumn('device_id');
+            }
         });
     }
 };


### PR DESCRIPTION
- Changed `league_id` and `device_id` columns to use `unsignedBigInteger` type for improved compatibility.
- Removed foreign key constraints for `league_id` and `device_id`, simplifying the migration process.