### PR TITLE
fix: prevent migration from recreating league_device table if it already exists

### DIFF
--- a/database/migrations/2026_06_16_000002_create_league_device_table.php
+++ b/database/migrations/2026_06_16_000002_create_league_device_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('league_device')) {
+            return;
+        }
+
         Schema::create('league_device', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('league_id');


### PR DESCRIPTION
- Added a check to ensure the `league_device` table is not recreated if it already exists, preventing potential migration errors.