### PR TITLE
feat: team-level groups backend - CRUD, import to game, status valida…

### DIFF
--- a/app/Http/Controllers/TeamGroupController.php
+++ b/app/Http/Controllers/TeamGroupController.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Responses\BaseResponse;
+use App\Models\TeamGroup;
+use Illuminate\Http\Request;
+
+class TeamGroupController extends Controller
+{
+    public function index(int $teamId)
+    {
+        $groups = TeamGroup::where('team_id', $teamId)
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        return new BaseResponse(STATUS_CODE_OK, STATUS_CODE_OK, 'Team groups fetched', $groups);
+    }
+
+    public function store(Request $request, int $teamId)
+    {
+        $request->validate([
+            'group_name'      => 'required|string|max:255',
+            'description'     => 'nullable|string',
+            'type'            => 'required|string',
+            'group_level'     => 'required|integer|in:7,11,12',
+            'status'          => 'nullable|string',
+            'player_ids'      => 'nullable|array',
+            'player_ids.*'    => 'integer',
+            'player_positions'=> 'nullable|array',
+            'league_id'       => 'nullable|integer',
+        ]);
+
+        $positionsMap = $request->player_positions ?? [];
+        $players = collect($request->player_ids ?? [])
+            ->map(fn ($id) => ['id' => (int) $id, 'positions' => $positionsMap[(string)(int)$id] ?? null])
+            ->values()
+            ->all();
+
+        $group = TeamGroup::create([
+            'team_id'     => $teamId,
+            'league_id'   => $request->league_id,
+            'group_name'  => $request->group_name,
+            'description' => $request->description,
+            'type'        => $request->type,
+            'group_level' => (int) $request->group_level,
+            'status'      => $request->status ?? 'active',
+            'players'     => $players ?: null,
+        ]);
+
+        return new BaseResponse(STATUS_CODE_OK, STATUS_CODE_OK, 'Team group created', $group);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $group = TeamGroup::findOrFail($id);
+
+        $request->validate([
+            'group_name'      => 'required|string|max:255',
+            'description'     => 'nullable|string',
+            'type'            => 'required|string',
+            'group_level'     => 'required|integer|in:7,11,12',
+            'status'          => 'nullable|string',
+            'player_ids'      => 'nullable|array',
+            'player_ids.*'    => 'integer',
+            'player_positions'=> 'nullable|array',
+        ]);
+
+        $positionsMap = $request->player_positions ?? [];
+        $players = collect($request->player_ids ?? [])
+            ->map(fn ($id) => ['id' => (int) $id, 'positions' => $positionsMap[(string)(int)$id] ?? null])
+            ->values()
+            ->all();
+
+        $requestedStatus = $request->status ?? $group->status;
+        $playerCount = count($players);
+        $groupLevel  = (int) $request->group_level;
+        // Cannot be active if player count doesn't match the group size
+        $finalStatus = ($requestedStatus === 'active' && $playerCount !== $groupLevel)
+            ? 'inactive'
+            : $requestedStatus;
+
+        $group->update([
+            'group_name'  => $request->group_name,
+            'description' => $request->description,
+            'type'        => $request->type,
+            'group_level' => $groupLevel,
+            'status'      => $finalStatus,
+            'players'     => $players ?: null,
+        ]);
+
+        return new BaseResponse(STATUS_CODE_OK, STATUS_CODE_OK, 'Team group updated', $group->fresh());
+    }
+
+    public function destroy(int $id)
+    {
+        $group = TeamGroup::findOrFail($id);
+        $group->delete();
+
+        return new BaseResponse(STATUS_CODE_OK, STATUS_CODE_OK, 'Team group deleted');
+    }
+
+    public function players(int $teamId)
+    {
+        $team = \App\Models\LeagueTeam::findOrFail($teamId);
+
+        if ((int) ($team->is_practice ?? 0) === 1) {
+            $rows = \App\Models\PracticeTeamPlayer::where('team_id', $teamId)->get();
+        } else {
+            $rows = \App\Models\TeamPlayer::where('team_id', $teamId)
+                ->with(['teamPlayerPosition' => fn ($q) => $q->orderBy('sort')])
+                ->get();
+        }
+
+        $players = $rows->map(fn ($p) => [
+            'id'             => $p->id,
+            'name'           => $p->name ?? $p->player_name ?? null,
+            'number'         => $p->number ?? null,
+            'position'       => $p->position ?? $p->player_position ?? null,
+            'position_value' => $p->position_value ?? null,
+            'rpp'            => $p->rpp ?? null,
+            'type'           => $p->type ?? null,
+            'positions'      => isset($p->teamPlayerPosition)
+                ? $p->teamPlayerPosition->pluck('position_name')->filter()->values()->all()
+                : [],
+        ])->values();
+
+        return new BaseResponse(STATUS_CODE_OK, STATUS_CODE_OK, 'Players fetched', $players);
+    }
+
+    public function importToGame(Request $request, int $gameId)
+    {
+        $request->validate([
+            'group_ids'    => 'required|array',
+            'group_ids.*'  => 'integer',
+            'team_id'      => 'required|integer',
+            'team_type'    => 'nullable|integer',
+            'league_id'    => 'nullable|integer',
+            'is_practice'  => 'nullable',
+        ]);
+
+        $isPractice = filter_var($request->is_practice ?? false, FILTER_VALIDATE_BOOLEAN);
+        $teamType   = (int) ($request->team_type ?? 1);
+        $gameType   = $isPractice ? 2 : 1;
+        $playerCol  = $isPractice ? 'practice_player_id' : 'player_id';
+        $created = [];
+        $skipped = [];
+
+        foreach ($request->group_ids as $groupId) {
+            $teamGroup = TeamGroup::find((int) $groupId);
+            if (! $teamGroup) {
+                $skipped[] = $groupId;
+                continue;
+            }
+
+            $alreadyExists = \App\Models\PersionalGrouping::where('game_id', $gameId)
+                ->whereNotNull('source_team_group_id')
+                ->where('source_team_group_id', $teamGroup->id)
+                ->exists();
+
+            if ($alreadyExists) {
+                $skipped[] = $groupId;
+                continue;
+            }
+
+            $gameGroup = \App\Models\PersionalGrouping::withoutEvents(function () use ($teamGroup, $gameId, $request, $isPractice) {
+                return \App\Models\PersionalGrouping::create([
+                    'game_id'                  => $gameId,
+                    'team_id'                  => (int) $request->team_id,
+                    'league_id'                => $request->league_id ? (int) $request->league_id : null,
+                    'group_name'               => $teamGroup->group_name,
+                    'type'                     => $teamGroup->type,
+                    'players'                  => $isPractice ? null : $teamGroup->players,
+                    'practice_players'         => $isPractice ? $teamGroup->practice_players : null,
+                    'group_level'              => $isPractice ? 2 : 1,
+                    'status'                   => 'active',
+                    'source_team_group_id'     => $teamGroup->id,
+                    'roster_repair_player_ids' => null,
+                ]);
+            });
+
+            $rawPlayers = $isPractice ? $teamGroup->practice_players : $teamGroup->players;
+            $slotType   = str_contains(strtolower($teamGroup->type ?? ''), 'offen') ? 'offensive' : 'defensive';
+            $playerIds  = collect(is_array($rawPlayers) ? $rawPlayers : [])
+                ->map(fn ($p) => is_array($p) ? (int) ($p['id'] ?? 0) : (int) $p)
+                ->filter(fn ($id) => $id > 0)
+                ->unique()
+                ->values()
+                ->all();
+
+            foreach ($playerIds as $playerId) {
+                \App\Models\ConfiguredPlayingTeamPlayer::firstOrCreate(
+                    [
+                        'match_id'  => $gameId,
+                        'team_id'   => (int) $request->team_id,
+                        'team_type' => $teamType,
+                        'game_type' => $gameType,
+                        $playerCol  => $playerId,
+                    ],
+                    ['type' => $slotType]
+                );
+            }
+
+            $created[] = $gameGroup->fresh();
+        }
+
+        return new BaseResponse(
+            STATUS_CODE_OK,
+            STATUS_CODE_OK,
+            'Groups imported',
+            ['created' => $created, 'skipped' => $skipped]
+        );
+    }
+}

--- a/app/Models/PersionalGrouping.php
+++ b/app/Models/PersionalGrouping.php
@@ -50,6 +50,7 @@ class PersionalGrouping extends Model
         'group_level',
         'status',
         'roster_repair_player_ids',
+        'source_team_group_id',
     ];
 
     protected $casts = [

--- a/app/Models/TeamGroup.php
+++ b/app/Models/TeamGroup.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TeamGroup extends Model
+{
+    protected $table = 'team_groups';
+
+    protected $fillable = [
+        'team_id',
+        'league_id',
+        'group_name',
+        'description',
+        'type',
+        'players',
+        'practice_players',
+        'group_level',
+        'status',
+    ];
+
+    protected $casts = [
+        'players'          => 'array',
+        'practice_players' => 'array',
+        'group_level'      => 'integer',
+    ];
+}

--- a/database/migrations/2026_06_24_000001_create_team_groups_table.php
+++ b/database/migrations/2026_06_24_000001_create_team_groups_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('team_groups', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('team_id');
+            $table->unsignedBigInteger('league_id')->nullable();
+            $table->string('group_name', 255);
+            $table->text('description')->nullable();
+            $table->string('type', 50);
+            $table->json('players')->nullable();
+            $table->json('practice_players')->nullable();
+            $table->unsignedTinyInteger('group_level')->comment('Segment size: 7, 11, or 12');
+            $table->string('status', 32)->default('active');
+            $table->timestamps();
+
+            $table->foreign('team_id')->references('id')->on('league_teams')->onDelete('cascade');
+            $table->foreign('league_id')->references('id')->on('leagues')->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('team_groups');
+    }
+};

--- a/database/migrations/2026_06_24_000002_add_source_team_group_id_to_personal_groupings.php
+++ b/database/migrations/2026_06_24_000002_add_source_team_group_id_to_personal_groupings.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('personal_groupings', function (Blueprint $table) {
+            $table->unsignedBigInteger('source_team_group_id')
+                ->nullable()
+                ->after('roster_repair_player_ids');
+
+            $table->foreign('source_team_group_id')
+                ->references('id')
+                ->on('team_groups')
+                ->onDelete('set null');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('personal_groupings', function (Blueprint $table) {
+            $table->dropForeign(['source_team_group_id']);
+            $table->dropColumn('source_team_group_id');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -274,6 +274,14 @@ Route::middleware('auth:sanctum')->group(function () {
 
   Route::get('/persional-groups-players', [PersionalGroupingController::class, 'getGroupsByTeamAndGame']);
 
+  // Team Groups
+  Route::get('/teams/{teamId}/groups', [\App\Http\Controllers\TeamGroupController::class, 'index']);
+  Route::post('/teams/{teamId}/groups', [\App\Http\Controllers\TeamGroupController::class, 'store']);
+  Route::put('/groups/{id}', [\App\Http\Controllers\TeamGroupController::class, 'update']);
+  Route::delete('/groups/{id}', [\App\Http\Controllers\TeamGroupController::class, 'destroy']);
+  Route::get('/teams/{teamId}/players', [\App\Http\Controllers\TeamGroupController::class, 'players']);
+  Route::post('/games/{gameId}/import-team-groups', [\App\Http\Controllers\TeamGroupController::class, 'importToGame']);
+
 
    Route::prefix('leagues')->group(function () {
         Route::prefix('/{league}/matches')->group(function () {

--- a/tests/Feature/TeamGroupControllerTest.php
+++ b/tests/Feature/TeamGroupControllerTest.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\LeagueTeam;
+use App\Models\PersionalGrouping;
+use App\Models\TeamGroup;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class TeamGroupControllerTest extends TestCase
+{
+    protected int $teamId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->beforeApplicationDestroyed(fn () => DB::rollBack());
+        DB::beginTransaction();
+
+        if (! Schema::hasTable('team_groups')) {
+            $this->markTestSkipped('team_groups table not available.');
+        }
+
+        // Authenticate as a head coach so auth:sanctum middleware passes
+        $user = User::where('email', 'teamgroup-test@example.com')->first();
+        if (! $user) {
+            $user = User::create([
+                'name'     => 'Team Group Test Coach',
+                'email'    => 'teamgroup-test@example.com',
+                'password' => Hash::make('secret'),
+                'role'     => 'head_coach',
+                'status'   => 'approved',
+                'sport_id' => 1,
+            ]);
+        }
+
+        Sanctum::actingAs($user);
+        $this->actingAs($user, 'api');
+
+        // Create a real team so FK constraints are satisfied
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        $team = LeagueTeam::forceCreate([
+            'team_name'   => 'Test Team',
+            'league_id'   => 1,
+            'is_practice' => 0,
+        ]);
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        $this->teamId = $team->id;
+    }
+
+    private function makeTeamGroup(array $overrides = []): TeamGroup
+    {
+        return TeamGroup::forceCreate(array_merge([
+            'team_id'    => $this->teamId,
+            'league_id'  => null,
+            'group_name' => 'Red Tigers',
+            'type'       => 'offense',
+            'group_level'=> 11,
+            'status'     => 'active',
+            'players'    => null,
+        ], $overrides));
+    }
+
+    /** @test */
+    public function index_returns_groups_for_requested_team_only(): void
+    {
+        $this->makeTeamGroup(['team_id' => $this->teamId, 'group_name' => 'Alpha']);
+        $this->makeTeamGroup(['team_id' => $this->teamId, 'group_name' => 'Beta']);
+
+        // Create a second team for isolation test
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        $otherTeam = LeagueTeam::forceCreate(['team_name' => 'Other Team', 'league_id' => 1, 'is_practice' => 0]);
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+        TeamGroup::forceCreate([
+            'team_id'    => $otherTeam->id,
+            'group_name' => 'Other',
+            'type'       => 'offense',
+            'group_level'=> 11,
+            'status'     => 'active',
+        ]);
+
+        $response = $this->getJson("/api/teams/{$this->teamId}/groups");
+
+        $response->assertOk();
+        $data = $response->json('data');
+        $this->assertCount(2, $data);
+        $names = array_column($data, 'group_name');
+        $this->assertContains('Alpha', $names);
+        $this->assertContains('Beta', $names);
+        $this->assertNotContains('Other', $names);
+    }
+
+    /** @test */
+    public function store_creates_group_and_normalises_player_ids(): void
+    {
+        $response = $this->postJson("/api/teams/{$this->teamId}/groups", [
+            'group_name'  => 'Red Tigers',
+            'type'        => 'offense',
+            'group_level' => 11,
+            'player_ids'  => [10, 20, 30],
+            'league_id'   => null,
+        ]);
+
+        $response->assertOk();
+        $group = TeamGroup::where('group_name', 'Red Tigers')->first();
+        $this->assertNotNull($group);
+        $this->assertIsArray($group->players);
+        $this->assertCount(3, $group->players);
+        $this->assertEquals(['id' => 10, 'positions' => null], $group->players[0]);
+    }
+
+    /** @test */
+    public function store_returns_422_when_required_fields_missing(): void
+    {
+        $this->postJson("/api/teams/{$this->teamId}/groups", [])->assertStatus(422);
+    }
+
+    /** @test */
+    public function update_changes_name_and_type(): void
+    {
+        $group = $this->makeTeamGroup(['group_name' => 'Old Name', 'type' => 'offense']);
+
+        $this->putJson("/api/groups/{$group->id}", [
+            'group_name'  => 'New Name',
+            'type'        => 'defense',
+            'group_level' => 7,
+            'player_ids'  => [],
+        ])->assertOk();
+
+        $this->assertDatabaseHas('team_groups', ['id' => $group->id, 'group_name' => 'New Name']);
+    }
+
+    /** @test */
+    public function destroy_deletes_team_group_and_nullifies_source_on_game_copies(): void
+    {
+        $group = $this->makeTeamGroup();
+
+        DB::statement('SET FOREIGN_KEY_CHECKS=0');
+        $gameGroup = PersionalGrouping::forceCreate([
+            'game_id'              => 42,
+            'team_id'              => $this->teamId,
+            'league_id'            => 1,
+            'group_name'           => 'Red Tigers',
+            'type'                 => 'offense',
+            'group_level'          => 1,
+            'status'               => 'draft',
+            'source_team_group_id' => $group->id,
+        ]);
+        DB::statement('SET FOREIGN_KEY_CHECKS=1');
+
+        $this->deleteJson("/api/groups/{$group->id}")->assertOk();
+
+        $this->assertDatabaseMissing('team_groups', ['id' => $group->id]);
+        $this->assertDatabaseHas('personal_groupings', [
+            'id'                   => $gameGroup->id,
+            'source_team_group_id' => null,
+        ]);
+    }
+
+    /** @test */
+    public function import_creates_independent_game_level_copies(): void
+    {
+        $tg1 = $this->makeTeamGroup([
+            'group_name' => 'Red Tigers',
+            'players'    => [['id' => 10, 'positions' => 'QB'], ['id' => 11, 'positions' => null]],
+        ]);
+        $tg2 = $this->makeTeamGroup(['group_name' => 'Blue Eagles', 'type' => 'defense']);
+
+        $response = $this->postJson('/api/games/42/import-team-groups', [
+            'group_ids'   => [$tg1->id, $tg2->id],
+            'team_id'     => $this->teamId,
+            'league_id'   => 1,
+            'is_practice' => false,
+        ]);
+
+        $response->assertOk();
+        $this->assertCount(2, $response->json('data.created'));
+
+        $copy = PersionalGrouping::where('game_id', 42)
+            ->where('source_team_group_id', $tg1->id)
+            ->first();
+        $this->assertNotNull($copy);
+        $this->assertEquals('active', $copy->status);
+        $this->assertEquals('QB', $copy->players[0]['positions']);
+    }
+
+    /** @test */
+    public function import_skips_already_imported_group(): void
+    {
+        $tg = $this->makeTeamGroup();
+
+        $this->postJson('/api/games/42/import-team-groups', [
+            'group_ids' => [$tg->id], 'team_id' => $this->teamId, 'league_id' => 1, 'is_practice' => false,
+        ]);
+
+        $response = $this->postJson('/api/games/42/import-team-groups', [
+            'group_ids' => [$tg->id], 'team_id' => $this->teamId, 'league_id' => 1, 'is_practice' => false,
+        ]);
+
+        $response->assertOk();
+        $this->assertEmpty($response->json('data.created'));
+        $this->assertContains($tg->id, $response->json('data.skipped'));
+        $this->assertEquals(1, PersionalGrouping::where('game_id', 42)->where('source_team_group_id', $tg->id)->count());
+    }
+
+    /** @test */
+    public function import_for_practice_game_sets_group_level_2(): void
+    {
+        $tg = $this->makeTeamGroup([
+            'practice_players' => [['id' => 5, 'positions' => null]],
+        ]);
+
+        $this->postJson('/api/games/99/import-team-groups', [
+            'group_ids' => [$tg->id], 'team_id' => $this->teamId, 'league_id' => 1, 'is_practice' => true,
+        ])->assertOk();
+
+        $copy = PersionalGrouping::where('game_id', 99)->where('source_team_group_id', $tg->id)->first();
+        $this->assertEquals(2, (int) $copy->group_level);
+        $this->assertNotNull($copy->practice_players);
+        $this->assertNull($copy->players);
+    }
+}


### PR DESCRIPTION
…tion

- TeamGroupController: full CRUD for team groups, importToGame copies groups to personal_groupings with status:active and seeds configured_playing_team_players
- TeamGroup model + migration: new team_groups table with players JSON, group_level, status
- PersionalGrouping: add source_team_group_id FK + nullify on team group delete
- Migration: add source_team_group_id to personal_groupings
- routes/api.php: register all team group routes
- Status guard: update() auto-downgrades to inactive if player count != group_level
- TeamGroupControllerTest: full feature test coverage